### PR TITLE
To prevent Carla from moving we should apply approximately 700 Nm of torque.

### DIFF
--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -62,7 +62,7 @@ class Controller(object):
 
         if linear_vel == 0. and current_vel < 0.1:
             throttle = 0
-            brake = 400 # N*m - to hold the car in place if we are stopped at a light. Acceleration - 1m/s^2
+            brake = 700 # N*m - to hold the car in place if we are stopped at a light. Acceleration - 1m/s^2
 
         elif throttle < .1 and vel_error < 0:
             throttle = 0


### PR DESCRIPTION
In the walkthrough, only 400 Nm of torque is applied to hold the vehicle stationary. This turns out to be slightly less than the amount of force needed, and Carla will roll forward with only 400Nm of torque. To prevent Carla from moving we should apply approximately 700 Nm of torque.

The note above is from the "DBW Walkthrough" (below the video) at https://classroom.udacity.com/nanodegrees/nd013/parts/6047fe34-d93c-4f50-8336-b70ef10cb4b2/modules/e1a23b06-329a-4684-a717-ad476f0d8dff/lessons/462c933d-9f24-42d3-8bdc-a08a5fc866e4/concepts/6546d82d-6028-4210-a4b0-9d559662a881